### PR TITLE
[fix] CMakeList.txt 전역 통합 설정 주석처리

### DIFF
--- a/Setup.bat
+++ b/Setup.bat
@@ -105,12 +105,14 @@ echo [3/4] 필수 라이브러리 설치 (시간이 걸립니다)...
 "%VCPKG_EXE%" install assimp:x64-windows
 "%VCPKG_EXE%" install physx:x64-windows
 
+
 REM -----------------------------------------------------------
-REM [5] Visual Studio 통합
+REM [5] Visual Studio 통합(삭제)
 REM -----------------------------------------------------------
 echo.
 echo [4/4] Visual Studio 통합 설정 (User-wide)
-"%VCPKG_EXE%" integrate install
+REM "%VCPKG_EXE%" integrate install
+"%VCPKG_EXE%" integrate remove
 
 echo.
 echo ========================================================


### PR DESCRIPTION
REM "%VCPKG_EXE%" integrate install << 주석처리함
"%VCPKG_EXE%" integrate remove << 추가함(있으면 PhysX Extension을 Release로 읽어오는 문제가 있음)

생각해보니가 Setup.bat 수정한거임