### PR TITLE
[FIX] 각 기즈모의 이동이 서로 간섭하지 않게 분리함

### DIFF
--- a/Assets/Fbx/Alice.fbxasset
+++ b/Assets/Fbx/Alice.fbxasset
@@ -1,0 +1,30 @@
+{
+    "materials": [
+        "Assets/Materials/Alice_0.mat",
+        "Assets/Materials/Alice_1.mat",
+        "Assets/Materials/Alice_2.mat",
+        "Assets/Materials/Alice_3.mat",
+        "Assets/Materials/Alice_4.mat",
+        "Assets/Materials/Alice_5.mat",
+        "Assets/Materials/Alice_6.mat",
+        "Assets/Materials/Alice_7.mat",
+        "Assets/Materials/Alice_8.mat",
+        "Assets/Materials/Alice_9.mat",
+        "Assets/Materials/Alice_10.mat",
+        "Assets/Materials/Alice_11.mat",
+        "Assets/Materials/Alice_12.mat",
+        "Assets/Materials/Alice_13.mat",
+        "Assets/Materials/Alice_14.mat",
+        "Assets/Materials/Alice_15.mat",
+        "Assets/Materials/Alice_16.mat",
+        "Assets/Materials/Alice_17.mat",
+        "Assets/Materials/Alice_18.mat",
+        "Assets/Materials/Alice_19.mat",
+        "Assets/Materials/Alice_20.mat",
+        "Assets/Materials/Alice_21.mat",
+        "Assets/Materials/Alice_22.mat",
+        "Assets/Materials/Alice_23.mat"
+    ],
+    "mesh": "Alice",
+    "source_fbx": "Resource/Test/fbx/Alice3DGame/Alice.fbx"
+}

--- a/Assets/Fbx/AmazingWonderland.fbxasset
+++ b/Assets/Fbx/AmazingWonderland.fbxasset
@@ -1,0 +1,12 @@
+{
+    "materials": [
+        "Assets/Materials/AmazingWonderland_0.mat",
+        "Assets/Materials/AmazingWonderland_1.mat",
+        "Assets/Materials/AmazingWonderland_2.mat",
+        "Assets/Materials/AmazingWonderland_3.mat",
+        "Assets/Materials/AmazingWonderland_4.mat",
+        "Assets/Materials/AmazingWonderland_5.mat"
+    ],
+    "mesh": "AmazingWonderland",
+    "source_fbx": "Resource/Test/fbx/Alice3DGame/AmazingWonderland.fbx"
+}

--- a/Assets/Scenes/DuellumCycli/ProtoCombat.scene
+++ b/Assets/Scenes/DuellumCycli/ProtoCombat.scene
@@ -1,0 +1,4560 @@
+{
+    "entities": [
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/Cube_0.mat",
+                "color": {
+                    "x": 0.3199999928474426,
+                    "y": 0.3199999928474426,
+                    "z": 0.3199999928474426
+                },
+                "metalness": 0.0,
+                "normalStrength": 0.7990000247955322,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.0010000000474974513,
+                "roughness": 1.0,
+                "shadingMode": -1
+            },
+            "PhysicsSceneSettings": {
+                "enableGroundPlane": true,
+                "enablePhysics": true,
+                "filterRevision": 0,
+                "fixedDt": 0.01666666753590107,
+                "gravity": [
+                    0.0,
+                    -9.8100004196167,
+                    0.0
+                ],
+                "groundCollideMask": 4294967295,
+                "groundDynamicFriction": 0.5,
+                "groundIgnoreLayers": 0,
+                "groundIsTrigger": false,
+                "groundLayerBits": 1,
+                "groundQueryMask": 4294967295,
+                "groundRestitution": 0.0,
+                "groundStaticFriction": 0.5,
+                "layerCollideMatrix": [
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ]
+                ],
+                "layerNames": [
+                    "Layer_0",
+                    "Layer_1",
+                    "Layer_2",
+                    "Layer_3",
+                    "Layer_4",
+                    "Layer_5",
+                    "Layer_6",
+                    "Layer_7",
+                    "Layer_8",
+                    "Layer_9",
+                    "Layer_10",
+                    "Layer_11",
+                    "Layer_12",
+                    "Layer_13",
+                    "Layer_14",
+                    "Layer_15",
+                    "Layer_16",
+                    "Layer_17",
+                    "Layer_18",
+                    "Layer_19",
+                    "Layer_20",
+                    "Layer_21",
+                    "Layer_22",
+                    "Layer_23",
+                    "Layer_24",
+                    "Layer_25",
+                    "Layer_26",
+                    "Layer_27",
+                    "Layer_28",
+                    "Layer_29",
+                    "Layer_30",
+                    "Layer_31"
+                ],
+                "layerQueryMatrix": [
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ],
+                    [
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true,
+                        true
+                    ]
+                ],
+                "maxSubsteps": 4
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/Cube.fbxasset",
+                "meshAssetPath": "Cube"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": 0.0,
+                    "y": -0.2626889944076538,
+                    "z": 0.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 20.0,
+                    "y": 0.10000000149011612,
+                    "z": 25.0
+                }
+            },
+            "guid": "9498212875056345579",
+            "name": "Ground"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/door_low_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 0.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": -0.9100000262260437,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/door_low.fbxasset",
+                "meshAssetPath": "door_low"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": -0.10597000271081924,
+                    "y": 0.10656899958848953,
+                    "z": -24.60457992553711
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.021649999544024467,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "5441817724085827682",
+            "name": "Door_Right"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/doorframe_low_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.009999999776482582,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/doorframe_low.fbxasset",
+                "meshAssetPath": "doorframe_low"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": -0.027009999379515648,
+                    "y": 0.0,
+                    "z": -24.09119987487793
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "2853699652422214071",
+            "name": "Door_Frame"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/door_low_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.468999981880188,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": -0.33000001311302185,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/door_low.fbxasset",
+                "meshAssetPath": "door_low"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": -0.05003900080919266,
+                    "y": 0.12182000279426575,
+                    "z": -24.62175941467285
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 3.1155660152435303,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "9159302721924717470",
+            "name": "Door_Left"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/boss_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.009999999776482582,
+                "roughness": 0.5,
+                "shadingMode": 5
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/boss.fbxasset",
+                "meshAssetPath": "boss"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 11.250060081481934
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "886391607353601006",
+            "name": "Boss"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/Cube_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": -0.7699999809265137,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/Cube.fbxasset",
+                "meshAssetPath": "Cube"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": 0.0,
+                    "y": 8.177847862243652,
+                    "z": 0.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": -0.0
+                },
+                "scale": {
+                    "x": 20.0,
+                    "y": 0.10000000149011612,
+                    "z": 25.0
+                }
+            },
+            "guid": "8036396224208734499",
+            "name": "Ceiling"
+        },
+        {
+            "PointLight": {
+                "color": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                },
+                "enabled": true,
+                "intensity": 32.215999603271484,
+                "range": 10.0
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": -8.467499732971191,
+                    "y": 2.850100040435791,
+                    "z": -13.146200180053711
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "15355330057086389115",
+            "name": "Point Light"
+        },
+        {
+            "AdvancedAnimation": {
+                "additive": {
+                    "alpha": 1.0,
+                    "autoAdvance": true,
+                    "clip": "",
+                    "enabled": false,
+                    "loop": false,
+                    "refClip": "",
+                    "speed": 1.0,
+                    "time": 0.0
+                },
+                "aim": {
+                    "enabled": false,
+                    "weight": 1.0,
+                    "yawRad": 0.0
+                },
+                "base": {
+                    "autoAdvance": false,
+                    "blend01": 0.017948569729924202,
+                    "clipA": "alice-Apose_arm|Crouch",
+                    "clipB": "alice-Apose_arm|Crouch",
+                    "enabled": true,
+                    "layerAlpha": 1.0,
+                    "loopA": false,
+                    "loopB": true,
+                    "speedA": 1.0,
+                    "speedB": 1.0,
+                    "timeA": 1.0,
+                    "timeB": 1.0
+                },
+                "enabled": true,
+                "ik": {
+                    "chainLength": 2,
+                    "enabled": true,
+                    "targetMS": {
+                        "x": -0.20000000298023224,
+                        "y": 0.0,
+                        "z": 0.10000000149011612
+                    },
+                    "tipBone": "Ball_L",
+                    "weight": 1.0
+                },
+                "ikChains": [
+                    {}
+                ],
+                "playing": true,
+                "procedural": {
+                    "seed": 0,
+                    "strength": 0.0,
+                    "timeSec": 0.0
+                },
+                "sockets": [
+                    {},
+                    {},
+                    {}
+                ],
+                "upper": {
+                    "autoAdvance": true,
+                    "blend01": 0.0,
+                    "clipA": "Aim",
+                    "clipB": "",
+                    "enabled": false,
+                    "layerAlpha": 1.0,
+                    "loopA": true,
+                    "loopB": true,
+                    "speedA": 1.0,
+                    "speedB": 1.0,
+                    "timeA": 0.0,
+                    "timeB": 0.0
+                }
+            },
+            "AttackDriver": {
+                "clipName": "alice-Apose_arm|Swing",
+                "endTimeSec": 0.20000000298023224,
+                "startTimeSec": 0.10000000149011612,
+                "traceGuid": "10970757830035052100"
+            },
+            "Health": {
+                "alive": true,
+                "currentHealth": 100.0,
+                "invulnDuration": 0.0,
+                "invulnRemaining": 0.0,
+                "maxHealth": 100.0,
+                "teamId": 1
+            },
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/Alice_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.0010000000474974513,
+                "roughness": 0.5,
+                "shadingMode": 5
+            },
+            "Scripts": [
+                {
+                    "enabled": true,
+                    "name": "CharacterAnimatorComponent",
+                    "props": {
+                        "m_additiveClip": "Recoil",
+                        "m_additiveDuration": 0.25,
+                        "m_additiveRefClip": "Idle",
+                        "m_aimWeight": 1.0,
+                        "m_aimYawDeg": 0.0,
+                        "m_attackClip": "alice-Apose_arm|Swing",
+                        "m_attackComputeColor": {
+                            "x": 1.0,
+                            "y": 0.20000000298023224,
+                            "z": 0.20000000298023224
+                        },
+                        "m_attackComputeDuration": 3.0,
+                        "m_attackComputeOffset": {
+                            "x": 0.0,
+                            "y": 1.0,
+                            "z": 1.0
+                        },
+                        "m_attackComputeSize": 6.0,
+                        "m_attackDuration": 1.5,
+                        "m_attackHitTime": 0.699999988079071,
+                        "m_attackPlaySpeed": 0.4000000059604645,
+                        "m_blendSpeed": 8.0,
+                        "m_crouchClip": "alice-Apose_arm|Crouch",
+                        "m_crouchDuration": 1.0,
+                        "m_enableAdditive": false,
+                        "m_enableAim": false,
+                        "m_enableFootIK": true,
+                        "m_enableIK": false,
+                        "m_enableUpperLayer": false,
+                        "m_gravity": 18.0,
+                        "m_idleClip": "alice-Apose_arm|Idle",
+                        "m_ikChainLength": 3,
+                        "m_ikLiftSpeed": 5.0,
+                        "m_ikTargetLocal": {
+                            "x": 0.0,
+                            "y": 1.2000000476837158,
+                            "z": 0.20000000298023224
+                        },
+                        "m_ikTipBone": "Hand_L",
+                        "m_ikWeight": 1.0,
+                        "m_jumpSpeed": 6.5,
+                        "m_leftFootBasePos": {
+                            "x": -0.20000000298023224,
+                            "y": 0.0,
+                            "z": 0.10000000149011612
+                        },
+                        "m_leftFootBone": "Ball_L",
+                        "m_maxLiftHeight": 0.5,
+                        "m_moveSpeed": 2.0,
+                        "m_runClip": "alice-Apose_arm|Run",
+                        "m_runMultiplier": 1.600000023841858,
+                        "m_socketName": "WeaponPoint",
+                        "m_socketParentBone": "Hand_R",
+                        "m_socketPos": {
+                            "x": 0.10000000149011612,
+                            "y": 0.05000000074505806,
+                            "z": 0.0
+                        },
+                        "m_socketRotDeg": {
+                            "x": 0.0,
+                            "y": 90.0,
+                            "z": 0.0
+                        },
+                        "m_socketScale": {
+                            "x": 1.0,
+                            "y": 1.0,
+                            "z": 1.0
+                        },
+                        "m_transitionDuration": 0.20000000298023224,
+                        "m_upperClip": "Aim",
+                        "m_walkClip": "alice-Apose_arm|Walk",
+                        "m_walkComputeColor": {
+                            "x": 0.800000011920929,
+                            "y": 0.800000011920929,
+                            "z": 0.800000011920929
+                        },
+                        "m_walkComputeDuration": 1.0,
+                        "m_walkComputeOffset": {
+                            "x": 0.0,
+                            "y": 0.10000000149011612,
+                            "z": 0.0
+                        },
+                        "m_walkComputeSize": 3.0,
+                        "m_walkSpawnInterval": 0.30000001192092896,
+                        "m_weaponObjName": "Weapon"
+                    }
+                }
+            ],
+            "SkinnedAnimation": {
+                "clipIndex": 9,
+                "playing": false,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 248,
+                "instanceAssetPath": "Assets/Fbx/Alice.fbxasset",
+                "meshAssetPath": "Alice"
+            },
+            "Socket": {
+                "sockets": [
+                    {
+                        "name": "RightHand",
+                        "parentBone": "手首.R",
+                        "position": {
+                            "x": 0.0,
+                            "y": 0.0,
+                            "z": 0.0
+                        },
+                        "rotation": {
+                            "x": 0.0,
+                            "y": 0.0,
+                            "z": 0.0
+                        },
+                        "scale": {
+                            "x": 1.0,
+                            "y": 1.0,
+                            "z": 1.0
+                        }
+                    },
+                    {
+                        "name": "APoint",
+                        "parentBone": "操作中心",
+                        "position": {
+                            "x": 0.0,
+                            "y": 0.0,
+                            "z": 0.0
+                        },
+                        "rotation": {
+                            "x": 0.0,
+                            "y": 0.0,
+                            "z": 0.0
+                        },
+                        "scale": {
+                            "x": 1.0,
+                            "y": 1.0,
+                            "z": 1.0
+                        }
+                    },
+                    {
+                        "name": "BPoint",
+                        "parentBone": "手捩1.L",
+                        "position": {
+                            "x": 0.0,
+                            "y": 0.0,
+                            "z": 0.0
+                        },
+                        "rotation": {
+                            "x": 0.0,
+                            "y": 0.0,
+                            "z": 0.0
+                        },
+                        "scale": {
+                            "x": 1.0,
+                            "y": 1.0,
+                            "z": 1.0
+                        }
+                    }
+                ]
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": 0.024741290137171745,
+                    "y": 0.0,
+                    "z": -0.18753786385059357
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 5.448447227478027,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "7962531513969683154",
+            "name": "Player"
+        },
+        {
+            "Camera": {
+                "FOV": 60.0,
+                "Far Plane": 1000.0,
+                "Near Plane": 0.10000000149011612,
+                "aspectOverride": 0.0,
+                "primary": true,
+                "useAspectOverride": false
+            },
+            "CameraBlend": {
+                "duration": 0.5,
+                "slowDuration": 0.0,
+                "slowTimeScale": 0.20000000298023224,
+                "slowTriggerT": 0.5,
+                "targetName": "",
+                "useSmoothStep": true
+            },
+            "CameraFollow": {
+                "aimDistance": 18.0,
+                "aimFovDeg": 45.0,
+                "allowManualOrbitInLockOn": false,
+                "baseDistance": 35.0,
+                "bossIntroDistance": 45.0,
+                "bossIntroFovDeg": 75.0,
+                "cameraTimeScale": 1.0,
+                "combatDistance": 28.0,
+                "combatFovDeg": 65.0,
+                "deathDistance": 55.0,
+                "deathFovDeg": 50.0,
+                "enableInput": true,
+                "enableLockOn": true,
+                "enabled": true,
+                "exploreDistance": 35.0,
+                "exploreFovDeg": 60.0,
+                "fastTurnMultiplier": 2.5,
+                "fastTurnYawThresholdDeg": 90.0,
+                "fovDamping": 6.0,
+                "heightOffset": 1.5,
+                "lockOnAngleWeight": 1.5,
+                "lockOnDistance": 24.0,
+                "lockOnFovDeg": 55.0,
+                "lockOnMaxAngleDeg": 50.0,
+                "lockOnMaxDistance": 35.0,
+                "lockOnRotationDamping": 10.0,
+                "lockOnSwitchAngleDeg": 45.0,
+                "maxDistance": 60.0,
+                "minDistance": 8.0,
+                "mode": 0,
+                "pitchDeg": 1.8777823448181152,
+                "pitchMaxDeg": 80.0,
+                "pitchMinDeg": -45.0,
+                "positionDamping": 8.0,
+                "rotationDamping": 12.0,
+                "sensitivity": 0.20000000298023224,
+                "shoulderOffset": 0.30000001192092896,
+                "shoulderSide": 1.0,
+                "targetName": "Player",
+                "yawDeg": 135.26539611816406
+            },
+            "CameraInput": {
+                "blendTimeKey3": 0.6000000238418579,
+                "blendTimeKey4": 0.6000000238418579,
+                "blendTimeKey5": 0.800000011920929,
+                "cameraListCsv": "Camera1,Camera2,Camera3,Camera4,Camera5",
+                "enabled": true,
+                "lookAtTargetName": "Enemy",
+                "shakeAmplitudeKey4": 0.30000001192092896,
+                "shakeDecayKey4": 2.0,
+                "shakeDurationKey4": 0.4000000059604645,
+                "shakeFrequencyKey4": 10.0,
+                "slowDurationKey5": 0.30000001192092896,
+                "slowTimeScaleKey5": 0.20000000298023224,
+                "slowTriggerTKey5": 0.5
+            },
+            "CameraLookAt": {
+                "enabled": false,
+                "rotationDamping": 8.0,
+                "targetName": "Enemy"
+            },
+            "CameraShake": {
+                "amplitude": 0.0,
+                "decay": 1.0,
+                "duration": 0.0,
+                "enabled": true,
+                "frequency": 20.0
+            },
+            "CameraSpringArm": {
+                "distance": 2.999998092651367,
+                "distanceDamping": 6.0,
+                "enableCollision": true,
+                "enableZoom": true,
+                "enabled": true,
+                "maxDistance": 3.0,
+                "minDistance": 1.0,
+                "minHeight": -1000.0,
+                "probePadding": 0.20000000298023224,
+                "probeRadius": 0.3499999940395355,
+                "zoomSpeed": 0.009999999776482582
+            },
+            "Scripts": [
+                {
+                    "enabled": true,
+                    "name": "CameraRigPreset",
+                    "props": {
+                        "m_applyEveryFrame": false,
+                        "m_blendTimeKey3": 0.6000000238418579,
+                        "m_blendTimeKey4": 0.6000000238418579,
+                        "m_blendTimeKey5": 0.800000011920929,
+                        "m_cameraListCsv": "Camera1,Camera2,Camera3,Camera4,Camera5",
+                        "m_followTargetName": "Player",
+                        "m_lookAtTargetName": "Enemy",
+                        "m_shakeAmplitudeKey4": 0.30000001192092896,
+                        "m_shakeDecayKey4": 2.0,
+                        "m_shakeDurationKey4": 0.4000000059604645,
+                        "m_shakeFrequencyKey4": 10.0,
+                        "m_slowDurationKey5": 0.30000001192092896,
+                        "m_slowTimeScaleKey5": 0.20000000298023224,
+                        "m_slowTriggerTKey5": 0.5,
+                        "m_springArmDistance": 2.0,
+                        "m_springArmMaxDistance": 3.0,
+                        "m_springArmMinDistance": 1.0,
+                        "m_springArmZoomSpeed": 0.009999999776482582
+                    }
+                }
+            ],
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": -2.2987096309661865,
+                    "y": 1.5983017683029175,
+                    "z": 1.731293797492981
+                },
+                "rotation": {
+                    "x": 0.03277348726987839,
+                    "y": 2.3608267307281494,
+                    "z": 3.725290298461914e-09
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "10427231408183436599",
+            "name": "Camera1"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/pillar_low_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.009999999776482582,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/pillar_low.fbxasset",
+                "meshAssetPath": "pillar_low"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": 8.25,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "1000000000001",
+            "name": "Pillar_Center_R_0"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/pillar_low_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.009999999776482582,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/pillar_low.fbxasset",
+                "meshAssetPath": "pillar_low"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": 8.25,
+                    "y": 2.0,
+                    "z": 0.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "1000000000002",
+            "name": "Pillar_Center_R_1"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/pillar_low_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.009999999776482582,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/pillar_low.fbxasset",
+                "meshAssetPath": "pillar_low"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": 8.25,
+                    "y": 4.0,
+                    "z": 0.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "1000000000003",
+            "name": "Pillar_Center_R_2"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/pillar_low_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.009999999776482582,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/pillar_low.fbxasset",
+                "meshAssetPath": "pillar_low"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": 8.25,
+                    "y": 6.0,
+                    "z": 0.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "1000000000004",
+            "name": "Pillar_Center_R_3"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/pillar_low_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.009999999776482582,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/pillar_low.fbxasset",
+                "meshAssetPath": "pillar_low"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": -11.880000114440918,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "1000000000005",
+            "name": "Pillar_Center_L_0"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/pillar_low_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.009999999776482582,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/pillar_low.fbxasset",
+                "meshAssetPath": "pillar_low"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": -11.880000114440918,
+                    "y": 2.0,
+                    "z": 0.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "1000000000006",
+            "name": "Pillar_Center_L_1"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/pillar_low_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.009999999776482582,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/pillar_low.fbxasset",
+                "meshAssetPath": "pillar_low"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": -11.880000114440918,
+                    "y": 4.0,
+                    "z": 0.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "1000000000007",
+            "name": "Pillar_Center_L_2"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/pillar_low_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.009999999776482582,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/pillar_low.fbxasset",
+                "meshAssetPath": "pillar_low"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": -11.880000114440918,
+                    "y": 6.0,
+                    "z": 0.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "1000000000008",
+            "name": "Pillar_Center_L_3"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/pillar_low_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.009999999776482582,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/pillar_low.fbxasset",
+                "meshAssetPath": "pillar_low"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": 8.25,
+                    "y": 0.0,
+                    "z": 12.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "1000000000009",
+            "name": "Pillar_Front_R_0"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/pillar_low_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.009999999776482582,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/pillar_low.fbxasset",
+                "meshAssetPath": "pillar_low"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": 8.25,
+                    "y": 2.0,
+                    "z": 12.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "1000000000010",
+            "name": "Pillar_Front_R_1"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/pillar_low_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.009999999776482582,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/pillar_low.fbxasset",
+                "meshAssetPath": "pillar_low"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": 8.25,
+                    "y": 4.0,
+                    "z": 12.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "1000000000011",
+            "name": "Pillar_Front_R_2"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/pillar_low_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.009999999776482582,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/pillar_low.fbxasset",
+                "meshAssetPath": "pillar_low"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": 8.25,
+                    "y": 6.0,
+                    "z": 12.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "1000000000012",
+            "name": "Pillar_Front_R_3"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/pillar_low_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.009999999776482582,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/pillar_low.fbxasset",
+                "meshAssetPath": "pillar_low"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": -11.880000114440918,
+                    "y": 0.0,
+                    "z": 12.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "1000000000013",
+            "name": "Pillar_Front_L_0"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/pillar_low_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.009999999776482582,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/pillar_low.fbxasset",
+                "meshAssetPath": "pillar_low"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": -11.880000114440918,
+                    "y": 2.0,
+                    "z": 12.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "1000000000014",
+            "name": "Pillar_Front_L_1"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/pillar_low_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.009999999776482582,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/pillar_low.fbxasset",
+                "meshAssetPath": "pillar_low"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": -11.880000114440918,
+                    "y": 4.0,
+                    "z": 12.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "1000000000015",
+            "name": "Pillar_Front_L_2"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/pillar_low_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.009999999776482582,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/pillar_low.fbxasset",
+                "meshAssetPath": "pillar_low"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": -11.880000114440918,
+                    "y": 6.0,
+                    "z": 12.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "1000000000016",
+            "name": "Pillar_Front_L_3"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/pillar_low_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.009999999776482582,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/pillar_low.fbxasset",
+                "meshAssetPath": "pillar_low"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": 8.25,
+                    "y": 0.0,
+                    "z": -12.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "1000000000017",
+            "name": "Pillar_Back_R_0"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/pillar_low_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.009999999776482582,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/pillar_low.fbxasset",
+                "meshAssetPath": "pillar_low"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": 8.25,
+                    "y": 2.0,
+                    "z": -12.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "1000000000018",
+            "name": "Pillar_Back_R_1"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/pillar_low_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.009999999776482582,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/pillar_low.fbxasset",
+                "meshAssetPath": "pillar_low"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": 8.25,
+                    "y": 4.0,
+                    "z": -12.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "1000000000019",
+            "name": "Pillar_Back_R_2"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/pillar_low_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.009999999776482582,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/pillar_low.fbxasset",
+                "meshAssetPath": "pillar_low"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": 8.25,
+                    "y": 6.0,
+                    "z": -12.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "1000000000020",
+            "name": "Pillar_Back_R_3"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/pillar_low_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.009999999776482582,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/pillar_low.fbxasset",
+                "meshAssetPath": "pillar_low"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": -11.880000114440918,
+                    "y": 0.0,
+                    "z": -12.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "1000000000021",
+            "name": "Pillar_Back_L_0"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/pillar_low_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.009999999776482582,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/pillar_low.fbxasset",
+                "meshAssetPath": "pillar_low"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": -11.880000114440918,
+                    "y": 2.0,
+                    "z": -12.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "1000000000022",
+            "name": "Pillar_Back_L_1"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/pillar_low_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.009999999776482582,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/pillar_low.fbxasset",
+                "meshAssetPath": "pillar_low"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": -11.880000114440918,
+                    "y": 4.0,
+                    "z": -12.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "1000000000023",
+            "name": "Pillar_Back_L_2"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/pillar_low_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.009999999776482582,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/pillar_low.fbxasset",
+                "meshAssetPath": "pillar_low"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": -11.880000114440918,
+                    "y": 6.0,
+                    "z": -12.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "1000000000024",
+            "name": "Pillar_Back_L_3"
+        },
+        {
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/AmazingWonderland_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.009999999776482582,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/AmazingWonderland.fbxasset",
+                "meshAssetPath": "AmazingWonderland"
+            },
+            "SocketAttachment": {
+                "extraPos": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "extraRotRad": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "extraScale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                },
+                "followScale": true,
+                "ownerGuid": "7962531513969683154",
+                "ownerNameDebug": "Player",
+                "socketName": "RightHand"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": -0.05209408700466156,
+                    "y": 0.7583783268928528,
+                    "z": -0.4370630979537964
+                },
+                "rotation": {
+                    "x": -0.2566399574279785,
+                    "y": 0.791734516620636,
+                    "z": -1.4747120141983032
+                },
+                "scale": {
+                    "x": 0.9999998211860657,
+                    "y": 1.0000005960464478,
+                    "z": 0.9999998211860657
+                }
+            },
+            "WeaponTrace": {
+                "active": true,
+                "attackInstanceId": 0,
+                "baseDamage": 10.0,
+                "debugDraw": true,
+                "ownerGuid": "7962531513969683154",
+                "ownerNameDebug": "Player",
+                "queryLayerBits": 0,
+                "radius": 10.0,
+                "targetLayerBits": 0,
+                "teamId": 0,
+                "traceSocketNames": [
+                    "RightHand",
+                    "APoint",
+                    "BPoint"
+                ]
+            },
+            "guid": "10970757830035052100",
+            "name": "Weapon"
+        },
+        {
+            "Health": {
+                "alive": true,
+                "currentHealth": 90.0,
+                "invulnDuration": 0.0,
+                "invulnRemaining": 0.0,
+                "maxHealth": 100.0,
+                "teamId": 1
+            },
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/Alice_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.009999999776482582,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 2,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 1028.6555851174053
+            },
+            "SkinnedMesh": {
+                "boneCount": 248,
+                "instanceAssetPath": "Assets/Fbx/Alice.fbxasset",
+                "meshAssetPath": "Alice"
+            },
+            "Socket": {
+                "sockets": [
+                    {
+                        "name": "HitPoint",
+                        "parentBone": "手捩.R",
+                        "position": {
+                            "x": 0.0,
+                            "y": 0.0,
+                            "z": 0.0
+                        },
+                        "rotation": {
+                            "x": 0.0,
+                            "y": 0.0,
+                            "z": 0.0
+                        },
+                        "scale": {
+                            "x": 1.0,
+                            "y": 1.0,
+                            "z": 1.0
+                        }
+                    }
+                ]
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "rotation": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "scale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                }
+            },
+            "guid": "5147235598097018399",
+            "name": "Enemy"
+        },
+        {
+            "Collider": {
+                "capsuleAlignYAxis": true,
+                "capsuleHalfHeight": 0.5,
+                "capsuleRadius": 0.5,
+                "dynamicFriction": 0.5,
+                "halfExtents": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                },
+                "ignoreLayers": 0,
+                "isTrigger": true,
+                "layerBits": 8,
+                "radius": 0.5,
+                "restitution": 0.0,
+                "staticFriction": 0.5,
+                "type": "Sphere"
+            },
+            "Hurtbox": {
+                "damageScale": 1.0,
+                "ownerGuid": "5147235598097018399",
+                "ownerNameDebug": "Enemy",
+                "part": 0,
+                "teamId": 1
+            },
+            "Material": {
+                "albedoTexturePath": "",
+                "assetPath": "Assets/Materials/IcoSphere_0.mat",
+                "color": {
+                    "x": 0.699999988079071,
+                    "y": 0.699999988079071,
+                    "z": 0.699999988079071
+                },
+                "metalness": 0.0,
+                "normalStrength": 1.0,
+                "outlineColor": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "outlineWidth": 0.009999999776482582,
+                "roughness": 0.5,
+                "shadingMode": -1
+            },
+            "RigidBody": {
+                "angularDamping": 0.05000000074505806,
+                "density": 1.0,
+                "enableCCD": false,
+                "enableSpeculativeCCD": false,
+                "gravityEnabled": false,
+                "isKinematic": true,
+                "linearDamping": 0.0,
+                "lockFlags": "None",
+                "massOverride": 0.0,
+                "maxAngularVelocity": 0.0,
+                "maxLinearVelocity": 0.0,
+                "resetVelocityOnTeleport": true,
+                "sleepThreshold": -1.0,
+                "solverPositionIterations": 4,
+                "solverVelocityIterations": 1,
+                "stabilizationThreshold": -1.0,
+                "startAwake": true,
+                "teleport": false
+            },
+            "SkinnedAnimation": {
+                "clipIndex": 0,
+                "playing": true,
+                "speed": 1.0,
+                "timeSec": 0.0
+            },
+            "SkinnedMesh": {
+                "boneCount": 1,
+                "instanceAssetPath": "Assets/Fbx/IcoSphere.fbxasset",
+                "meshAssetPath": "IcoSphere"
+            },
+            "SocketAttachment": {
+                "extraPos": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "extraRotRad": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "z": 0.0
+                },
+                "extraScale": {
+                    "x": 1.0,
+                    "y": 1.0,
+                    "z": 1.0
+                },
+                "followScale": false,
+                "ownerGuid": "5147235598097018399",
+                "ownerNameDebug": "Enemy",
+                "socketName": "HitPoint"
+            },
+            "Transform": {
+                "enabled": true,
+                "position": {
+                    "x": -0.20690059661865234,
+                    "y": 1.203792929649353,
+                    "z": 0.3756835162639618
+                },
+                "rotation": {
+                    "x": -1.138427495956421,
+                    "y": 3.0366008281707764,
+                    "z": -0.741120457649231
+                },
+                "scale": {
+                    "x": 0.20000000298023224,
+                    "y": 0.20000000298023224,
+                    "z": 0.20000000298023224
+                }
+            },
+            "guid": "11311314126236785267",
+            "name": "HitBox"
+        }
+    ],
+    "sceneName": "ProtoCombat",
+    "version": 1
+}

--- a/Assets/Scenes/DuellumCycli/ProtoCombat.ui.scene
+++ b/Assets/Scenes/DuellumCycli/ProtoCombat.ui.scene
@@ -1,0 +1,5 @@
+{
+    "sceneName": "ProtoCombat",
+    "uiEntities": [],
+    "version": 1
+}

--- a/src/Components/WeaponTraceComponent.h
+++ b/src/Components/WeaponTraceComponent.h
@@ -11,6 +11,27 @@
 
 namespace Alice
 {
+    enum class WeaponTraceShapeType : uint8_t
+    {
+        Sphere = 0,
+        Capsule = 1,
+        Box = 2,
+    };
+
+    struct WeaponTraceShape
+    {
+        std::string name = "Shape";
+        bool enabled = true;
+        WeaponTraceShapeType type = WeaponTraceShapeType::Sphere;
+
+        DirectX::XMFLOAT3 localPos{ 0.0f, 0.0f, 0.0f };
+        DirectX::XMFLOAT3 localRotDeg{ 0.0f, 0.0f, 0.0f };
+
+        float radius = 0.05f;
+        float capsuleHalfHeight = 0.20f;
+        DirectX::XMFLOAT3 boxHalfExtents{ 0.05f, 0.05f, 0.20f };
+    };
+
     struct WeaponTraceComponent
     {
         // 소켓 제공자 GUID (직렬화 대상)
@@ -20,10 +41,12 @@ namespace Alice
         // 런타임 캐시 (직렬화 금지)
         EntityId ownerCached = InvalidEntityId;
 
-        // 추적할 소켓 리스트 (Tip/Mid/Base 등)
-        std::vector<std::string> traceSocketNames;
+        // Trace 기준 엔티티 (무기 엔티티 등)
+        std::uint64_t traceBasisGuid = 0;
+        EntityId traceBasisCached = InvalidEntityId;
 
-        float radius = 0.05f;
+        std::vector<WeaponTraceShape> shapes;
+
         bool active = false;
         bool debugDraw = false;
         float baseDamage = 10.0f;
@@ -32,9 +55,15 @@ namespace Alice
         uint32_t targetLayerBits = 0;
         uint32_t queryLayerBits = 0;
 
-        // 내부 캐시
-        bool hasPrevPositions = false;
-        std::vector<DirectX::XMFLOAT3> prevPositions;
+        uint32_t subSteps = 1;
+
+        bool hasPrevBasis = false;
+        DirectX::XMFLOAT3 prevBasisPos{};
+        DirectX::XMFLOAT4 prevBasisRot{};
+
+        bool hasPrevShapes = false;
+        std::vector<DirectX::XMFLOAT3> prevCentersWS;
+        std::vector<DirectX::XMFLOAT4> prevRotsWS;
 
         uint32_t lastAttackInstanceId = 0;
         std::unordered_set<std::uint64_t> hitVictims;

--- a/src/Core/ComponentRegistry.cpp
+++ b/src/Core/ComponentRegistry.cpp
@@ -293,20 +293,39 @@ namespace Alice
 			.property("part", &HurtboxComponent::part)
 			.property("damageScale", &HurtboxComponent::damageScale);
 
+		rttr::registration::enumeration<WeaponTraceShapeType>("WeaponTraceShapeType")
+			(
+				rttr::value("Sphere", WeaponTraceShapeType::Sphere),
+				rttr::value("Capsule", WeaponTraceShapeType::Capsule),
+				rttr::value("Box", WeaponTraceShapeType::Box)
+				);
+
+		rttr::registration::class_<WeaponTraceShape>("WeaponTraceShape")
+			.constructor<>()
+			.property("name", &WeaponTraceShape::name)
+			.property("enabled", &WeaponTraceShape::enabled)
+			.property("type", &WeaponTraceShape::type)
+			.property("localPos", &WeaponTraceShape::localPos)
+			.property("localRotDeg", &WeaponTraceShape::localRotDeg)
+			.property("radius", &WeaponTraceShape::radius)
+			.property("capsuleHalfHeight", &WeaponTraceShape::capsuleHalfHeight)
+			.property("boxHalfExtents", &WeaponTraceShape::boxHalfExtents);
+
 		// WeaponTraceComponent 등록
 		rttr::registration::class_<WeaponTraceComponent>("WeaponTraceComponent")
 			.constructor<>()
 			.property("ownerGuid", &WeaponTraceComponent::ownerGuid)
 			.property("ownerNameDebug", &WeaponTraceComponent::ownerNameDebug)
-			.property("traceSocketNames", &WeaponTraceComponent::traceSocketNames)
-			.property("radius", &WeaponTraceComponent::radius)
+			.property("traceBasisGuid", &WeaponTraceComponent::traceBasisGuid)
+			.property("shapes", &WeaponTraceComponent::shapes)
 			.property("active", &WeaponTraceComponent::active)
 			.property("debugDraw", &WeaponTraceComponent::debugDraw)
 			.property("baseDamage", &WeaponTraceComponent::baseDamage)
 			.property("teamId", &WeaponTraceComponent::teamId)
 			.property("attackInstanceId", &WeaponTraceComponent::attackInstanceId)
 			.property("targetLayerBits", &WeaponTraceComponent::targetLayerBits)
-			.property("queryLayerBits", &WeaponTraceComponent::queryLayerBits);
+			.property("queryLayerBits", &WeaponTraceComponent::queryLayerBits)
+			.property("subSteps", &WeaponTraceComponent::subSteps);
 
 		// HealthComponent 등록
 		rttr::registration::class_<HealthComponent>("HealthComponent")

--- a/src/Core/Prefab.cpp
+++ b/src/Core/Prefab.cpp
@@ -503,9 +503,12 @@ namespace Alice
                 WeaponTraceComponent& wt = world.AddComponent<WeaponTraceComponent>(entity);
                 if (auto itGuid = itWT->find("ownerGuid"); itGuid != itWT->end())
                     wt.ownerGuid = ParseGuidOrZero(*itGuid);
+                if (auto itGuid = itWT->find("traceBasisGuid"); itGuid != itWT->end())
+                    wt.traceBasisGuid = ParseGuidOrZero(*itGuid);
 
                 JsonRttr::json copy = *itWT;
                 copy.erase("ownerGuid");
+                copy.erase("traceBasisGuid");
                 rttr::instance inst = wt;
                 if (!JsonRttr::FromJsonObject(inst, copy))
                     return InvalidEntityId;
@@ -794,6 +797,7 @@ namespace Alice
                 rttr::instance inst = const_cast<WeaponTraceComponent&>(*weaponTrace);
                 JsonRttr::json obj = JsonRttr::ToJsonObject(inst);
                 obj["ownerGuid"] = std::to_string(weaponTrace->ownerGuid);
+                obj["traceBasisGuid"] = std::to_string(weaponTrace->traceBasisGuid);
                 root["WeaponTrace"] = obj;
             }
 

--- a/src/Core/SceneFile.cpp
+++ b/src/Core/SceneFile.cpp
@@ -536,12 +536,7 @@ namespace Alice
                 rttr::instance inst = const_cast<WeaponTraceComponent&>(*weaponTrace);
                 JsonRttr::json obj = JsonRttr::ToJsonObject(inst);
                 obj["ownerGuid"] = std::to_string(weaponTrace->ownerGuid);
-                {
-                    JsonRttr::json names = JsonRttr::json::array();
-                    for (const auto& name : weaponTrace->traceSocketNames)
-                        names.push_back(name);
-                    obj["traceSocketNames"] = std::move(names);
-                }
+                obj["traceBasisGuid"] = std::to_string(weaponTrace->traceBasisGuid);
                 outEntity["WeaponTrace"] = obj;
             }
 
@@ -1091,14 +1086,12 @@ namespace Alice
                 WeaponTraceComponent& wt = world.AddComponent<WeaponTraceComponent>(id);
                 if (auto itGuid = itWeaponTrace->find("ownerGuid"); itGuid != itWeaponTrace->end())
                     wt.ownerGuid = ParseGuidOrZero(*itGuid);
+                if (auto itGuid = itWeaponTrace->find("traceBasisGuid"); itGuid != itWeaponTrace->end())
+                    wt.traceBasisGuid = ParseGuidOrZero(*itGuid);
 
                 JsonRttr::json copy = *itWeaponTrace;
                 copy.erase("ownerGuid");
-                if (auto itNames = copy.find("traceSocketNames"); itNames != copy.end())
-                {
-                    ReadStringArray(*itNames, wt.traceSocketNames);
-                    copy.erase("traceSocketNames");
-                }
+                copy.erase("traceBasisGuid");
                 rttr::instance inst = wt;
                 if (!JsonRttr::FromJsonObject(inst, copy)) return false;
             }

--- a/src/Editor/EditorCore.cpp
+++ b/src/Editor/EditorCore.cpp
@@ -3855,9 +3855,18 @@ namespace Alice
 							XMFLOAT3 newPosition, newRotation, newScale;
 							if (DecomposeLocalMatrix(localMatrix, newPosition, newRotation, newScale))
 							{
-								transform->position = newPosition;
-								transform->rotation = newRotation;  // (x=pitch, y=yaw, z=roll) 라디안
-								transform->scale = newScale;
+								if (gizmoOp == ImGuizmo::TRANSLATE)
+								{
+									transform->position = newPosition;
+								}
+								else if (gizmoOp == ImGuizmo::ROTATE)
+								{
+									transform->rotation = newRotation;  // (x=pitch, y=yaw, z=roll) 라디안
+								}
+								else if (gizmoOp == ImGuizmo::SCALE)
+								{
+									transform->scale = newScale;
+								}
 							}
 
 							// ImGuizmo로 Transform이 변경되었고 물리 컴포넌트가 있으면 텔레포트 자동 활성화

--- a/src/Editor/EditorCore.cpp
+++ b/src/Editor/EditorCore.cpp
@@ -8632,9 +8632,70 @@ namespace Alice
 
 				ImGui::Text("Owner Name: %s", trace->ownerNameDebug.empty() ? "(none)" : trace->ownerNameDebug.c_str());
 
+				std::uint64_t basisGuid = trace->traceBasisGuid;
+				if (ImGui::InputScalar("Trace Basis GUID", ImGuiDataType_U64, &basisGuid))
+				{
+					trace->traceBasisGuid = basisGuid;
+					trace->traceBasisCached = InvalidEntityId;
+					changed = true;
+				}
+
+				if (trace->traceBasisGuid == 0)
+					ImGui::TextDisabled("Trace Basis GUID is 0 -> uses self");
+
+				// Trace basis picker
+				{
+					std::string preview;
+					if (trace->traceBasisGuid == 0)
+					{
+						preview = "(self)";
+					}
+					else
+					{
+						EntityId resolved = world.FindEntityByGuid(trace->traceBasisGuid);
+						preview = (resolved != InvalidEntityId)
+							? world.GetEntityName(resolved)
+							: std::to_string(trace->traceBasisGuid);
+						if (preview.empty())
+							preview = std::to_string(trace->traceBasisGuid);
+					}
+
+					if (ImGui::BeginCombo("Trace Basis (pick entity)", preview.c_str()))
+					{
+						const bool selfSel = (trace->traceBasisGuid == 0);
+						if (ImGui::Selectable("(self)", selfSel))
+						{
+							trace->traceBasisGuid = 0;
+							trace->traceBasisCached = InvalidEntityId;
+							changed = true;
+						}
+						if (selfSel)
+							ImGui::SetItemDefaultFocus();
+
+						for (auto&& [eid, idc] : world.GetComponents<IDComponent>())
+						{
+							std::string label = world.GetEntityName(eid);
+							if (label.empty()) label = "Entity " + std::to_string(eid);
+							label += " (";
+							label += std::to_string(idc.guid);
+							label += ")";
+							const bool sel = (idc.guid == trace->traceBasisGuid);
+							if (ImGui::Selectable(label.c_str(), sel))
+							{
+								trace->traceBasisGuid = idc.guid;
+								trace->traceBasisCached = InvalidEntityId;
+								changed = true;
+							}
+							if (sel)
+								ImGui::SetItemDefaultFocus();
+						}
+						ImGui::EndCombo();
+					}
+				}
+
 				changed |= ImGui::Checkbox("Active", &trace->active);
 				changed |= ImGui::Checkbox("Debug Draw", &trace->debugDraw);
-				changed |= ImGui::DragFloat("Radius", &trace->radius, 0.01f, 0.0f, 10.0f);
+				changed |= ImGui::DragFloat("Base Damage", &trace->baseDamage, 0.1f, 0.0f, 100000.0f);
 
 				uint32_t teamId = trace->teamId;
 				if (ImGui::InputScalar("Team Id", ImGuiDataType_U32, &teamId))
@@ -8664,133 +8725,115 @@ namespace Alice
 					changed = true;
 				}
 
-				ImGui::Separator();
-				ImGui::Text("Trace Socket Names");
-
-				for (size_t i = 0; i < trace->traceSocketNames.size();)
+				uint32_t subSteps = trace->subSteps;
+				if (ImGui::InputScalar("Sub Steps", ImGuiDataType_U32, &subSteps))
 				{
+					trace->subSteps = std::max(1u, subSteps);
+					changed = true;
+				}
+
+				ImGui::Separator();
+				ImGui::Text("Trace Shapes");
+				if (ImGui::Button("Add Shape"))
+				{
+					trace->shapes.emplace_back();
+					changed = true;
+				}
+
+				for (size_t i = 0; i < trace->shapes.size(); ++i)
+				{
+					WeaponTraceShape& shape = trace->shapes[i];
 					ImGui::PushID(static_cast<int>(i));
-					ImGui::TextUnformatted(trace->traceSocketNames[i].c_str());
+
+					const char* typeName = (shape.type == WeaponTraceShapeType::Sphere)
+						? "Sphere"
+						: (shape.type == WeaponTraceShapeType::Capsule ? "Capsule" : "Box");
+					const char* namePreview = shape.name.empty() ? "(unnamed)" : shape.name.c_str();
+					bool open = ImGui::TreeNode("Shape", "%s [%s]", namePreview, typeName);
+
 					ImGui::SameLine();
-					if (ImGui::Button("Remove"))
+					bool moveUp = ImGui::SmallButton("^");
+					ImGui::SameLine();
+					bool moveDown = ImGui::SmallButton("v");
+					ImGui::SameLine();
+					bool duplicate = ImGui::SmallButton("Dup");
+					ImGui::SameLine();
+					bool remove = ImGui::SmallButton("Remove");
+
+					if (moveUp && i > 0)
 					{
-						trace->traceSocketNames.erase(trace->traceSocketNames.begin() + static_cast<long long>(i));
+						std::swap(trace->shapes[i - 1], trace->shapes[i]);
 						changed = true;
 						ImGui::PopID();
+						if (open) ImGui::TreePop();
 						continue;
 					}
+					if (moveDown && (i + 1) < trace->shapes.size())
+					{
+						std::swap(trace->shapes[i + 1], trace->shapes[i]);
+						changed = true;
+						ImGui::PopID();
+						if (open) ImGui::TreePop();
+						continue;
+					}
+					if (duplicate)
+					{
+						trace->shapes.insert(trace->shapes.begin() + static_cast<ptrdiff_t>(i + 1), shape);
+						changed = true;
+						ImGui::PopID();
+						if (open) ImGui::TreePop();
+						continue;
+					}
+					if (remove)
+					{
+						trace->shapes.erase(trace->shapes.begin() + static_cast<ptrdiff_t>(i));
+						changed = true;
+						ImGui::PopID();
+						if (open) ImGui::TreePop();
+						continue;
+					}
+
+					if (open)
+					{
+						char nameBuf[256];
+						std::snprintf(nameBuf, sizeof(nameBuf), "%.255s", shape.name.c_str());
+						if (ImGui::InputText("Name", nameBuf, sizeof(nameBuf)))
+						{
+							shape.name = nameBuf;
+							changed = true;
+						}
+
+						changed |= ImGui::Checkbox("Enabled", &shape.enabled);
+
+						const char* typeItems[] = { "Sphere", "Capsule", "Box" };
+						int typeIdx = static_cast<int>(shape.type);
+						if (ImGui::Combo("Type", &typeIdx, typeItems, IM_ARRAYSIZE(typeItems)))
+						{
+							shape.type = static_cast<WeaponTraceShapeType>(typeIdx);
+							changed = true;
+						}
+
+						changed |= ImGui::DragFloat3("Local Pos", &shape.localPos.x, 0.01f);
+						changed |= ImGui::DragFloat3("Local Rot (deg)", &shape.localRotDeg.x, 0.5f);
+
+						if (shape.type == WeaponTraceShapeType::Sphere)
+						{
+							changed |= ImGui::DragFloat("Radius", &shape.radius, 0.01f, 0.0f, 100.0f);
+						}
+						else if (shape.type == WeaponTraceShapeType::Capsule)
+						{
+							changed |= ImGui::DragFloat("Radius", &shape.radius, 0.01f, 0.0f, 100.0f);
+							changed |= ImGui::DragFloat("Half Height", &shape.capsuleHalfHeight, 0.01f, 0.0f, 100.0f);
+						}
+						else if (shape.type == WeaponTraceShapeType::Box)
+						{
+							changed |= ImGui::DragFloat3("Half Extents", &shape.boxHalfExtents.x, 0.01f, 0.0f, 100.0f);
+						}
+
+						ImGui::TreePop();
+					}
+
 					ImGui::PopID();
-					++i;
-				}
-
-				// Add from owner: combo to pick socket name (auto-recognize from owner)
-				EntityId traceOwnerId = (trace->ownerGuid != 0) ? world.FindEntityByGuid(trace->ownerGuid) : trace->ownerCached;
-				if (traceOwnerId != InvalidEntityId)
-				{
-					std::vector<std::string> ownerSocketOptions;
-					auto addOpt = [&ownerSocketOptions](const std::string& value) {
-						if (value.empty()) return;
-						if (std::find(ownerSocketOptions.begin(), ownerSocketOptions.end(), value) == ownerSocketOptions.end())
-							ownerSocketOptions.push_back(value);
-					};
-					if (const auto* sc = world.GetComponent<SocketComponent>(traceOwnerId))
-					{
-						for (const auto& s : sc->sockets)
-						{
-							addOpt(s.name);
-							if (!s.parentBone.empty() && s.parentBone != s.name)
-								addOpt(s.parentBone);
-						}
-					}
-					if (!ownerSocketOptions.empty() && ImGui::BeginCombo("Add from owner socket", "(select to add)"))
-					{
-						for (const auto& name : ownerSocketOptions)
-						{
-							bool already = std::find(trace->traceSocketNames.begin(), trace->traceSocketNames.end(), name) != trace->traceSocketNames.end();
-							if (already)
-								ImGui::BeginDisabled();
-							if (ImGui::Selectable(name.c_str()))
-							{
-								trace->traceSocketNames.push_back(name);
-								changed = true;
-							}
-							if (already)
-							{
-								ImGui::EndDisabled();
-								if (ImGui::IsItemHovered())
-									ImGui::SetTooltip("Already in list");
-							}
-						}
-						ImGui::EndCombo();
-					}
-				}
-
-				// Add new socket name input
-				static char newSocketBuf[128]{};
-				ImGui::SetNextItemWidth(200.0f);
-				bool addSocket = ImGui::InputText("##NewSocketName", newSocketBuf, IM_ARRAYSIZE(newSocketBuf), ImGuiInputTextFlags_EnterReturnsTrue);
-				if (addSocket || (ImGui::IsItemActive() && ImGui::IsKeyPressed(ImGuiKey_Enter)))
-				{
-					addSocket = true;
-				}
-				ImGui::SameLine();
-				if (ImGui::Button("Add##TraceSocket") || addSocket)
-				{
-					std::string newName = newSocketBuf;
-					// Trim whitespace
-					if (!newName.empty())
-					{
-						// Remove leading/trailing whitespace
-						size_t start = newName.find_first_not_of(" \t\n\r");
-						if (start != std::string::npos)
-						{
-							size_t end = newName.find_last_not_of(" \t\n\r");
-							newName = newName.substr(start, end - start + 1);
-						}
-						else
-						{
-							newName.clear();
-						}
-					}
-					
-					if (!newName.empty())
-					{
-						// Check for duplicates
-						bool isDuplicate = std::find(trace->traceSocketNames.begin(), trace->traceSocketNames.end(), newName) != trace->traceSocketNames.end();
-						if (!isDuplicate)
-						{
-							trace->traceSocketNames.push_back(newName);
-							changed = true;
-						}
-						// Clear input regardless of whether it was added
-						newSocketBuf[0] = '\0';
-					}
-				}
-				if (ImGui::IsItemHovered() && !std::string(newSocketBuf).empty())
-				{
-					ImGui::SetTooltip("Press Enter or click Add to add socket name");
-				}
-
-				if (ImGui::Button("Auto-fill Trace/WT sockets"))
-				{
-					EntityId ownerId = (trace->ownerGuid != 0) ? world.FindEntityByGuid(trace->ownerGuid) : trace->ownerCached;
-					if (ownerId != InvalidEntityId)
-					{
-						auto addIfMatch = [&](const std::string& name) {
-							if (name.rfind("Trace_", 0) != 0 && name.rfind("WT_", 0) != 0)
-								return;
-							for (const auto& s : trace->traceSocketNames)
-								if (s == name) return;
-							trace->traceSocketNames.push_back(name);
-							changed = true;
-						};
-
-						if (const auto* sc = world.GetComponent<SocketComponent>(ownerId))
-						{
-							for (const auto& s : sc->sockets)
-								addIfMatch(s.name);
-						}
-					}
 				}
 
 				if (changed) g_SceneDirty = true;

--- a/src/Game/AttackDriverSystem.cpp
+++ b/src/Game/AttackDriverSystem.cpp
@@ -37,8 +37,10 @@ namespace Alice
 
             trace->attackInstanceId++;
             trace->active = true;
-            trace->hasPrevPositions = false;
-            trace->prevPositions.clear();
+            trace->hasPrevBasis = false;
+            trace->hasPrevShapes = false;
+            trace->prevCentersWS.clear();
+            trace->prevRotsWS.clear();
             trace->hitVictims.clear();
             trace->lastAttackInstanceId = trace->attackInstanceId;
         }

--- a/src/Game/WeaponTraceSystem.cpp
+++ b/src/Game/WeaponTraceSystem.cpp
@@ -1,5 +1,6 @@
 #include "Game/WeaponTraceSystem.h"
 
+#include <algorithm>
 #include <cmath>
 #include <vector>
 
@@ -9,12 +10,10 @@
 #include "Components/IDComponent.h"
 #include "Components/WeaponTraceComponent.h"
 #include "Components/HurtboxComponent.h"
-#include "Components/AdvancedAnimationComponent.h"
-#include "Components/SocketComponent.h"
-#include "Components/SocketPoseOutputComponent.h"
 #include "Game/CombatPhysicsLayers.h"
 #include "Game/CombatHitEvent.h"
 #include "PhysX/IPhysicsWorld.h"
+#include "Core/Logger.h"
 
 namespace Alice
 {
@@ -45,63 +44,76 @@ namespace Alice
             return resolved;
         }
 
-        bool TryGetSocketWorldMatrix(World& world, EntityId owner, const std::string& socketName, DirectX::XMMATRIX& out)
+        EntityId ResolveTraceBasis(World& world, WeaponTraceComponent& trace, EntityId self)
         {
-            if (auto* poses = world.GetComponent<SocketPoseOutputComponent>(owner))
+            if (trace.traceBasisCached != InvalidEntityId)
             {
-                for (const auto& p : poses->poses)
+                if (trace.traceBasisGuid == 0)
+                    return trace.traceBasisCached;
+
+                if (const auto* idc = world.GetComponent<IDComponent>(trace.traceBasisCached))
                 {
-                    if (p.name == socketName)
-                    {
-                        out = DirectX::XMLoadFloat4x4(&p.world);
-                        return true;
-                    }
+                    if (idc->guid == trace.traceBasisGuid)
+                        return trace.traceBasisCached;
                 }
             }
 
-            // 1) Match by socket name (e.g. "Trace_Base", "Trace_Tip")
-            if (auto* adv = world.GetComponent<AdvancedAnimationComponent>(owner))
-            {
-                for (const auto& s : adv->sockets)
-                {
-                    if (s.name == socketName)
-                    {
-                        out = DirectX::XMLoadFloat4x4(&s.worldMatrix);
-                        return true;
-                    }
-                }
-                // 2) Fallback: match by parent bone name (e.g. "??.R")
-                for (const auto& s : adv->sockets)
-                {
-                    if (s.parentBone == socketName)
-                    {
-                        out = DirectX::XMLoadFloat4x4(&s.worldMatrix);
-                        return true;
-                    }
-                }
-            }
+            if (trace.traceBasisGuid == 0)
+                return self;
 
-            if (auto* sc = world.GetComponent<SocketComponent>(owner))
-            {
-                for (const auto& s : sc->sockets)
-                {
-                    if (s.name == socketName)
-                    {
-                        out = DirectX::XMLoadFloat4x4(&s.world);
-                        return true;
-                    }
-                }
-                for (const auto& s : sc->sockets)
-                {
-                    if (s.parentBone == socketName)
-                    {
-                        out = DirectX::XMLoadFloat4x4(&s.world);
-                        return true;
-                    }
-                }
-            }
+            EntityId resolved = world.FindEntityByGuid(trace.traceBasisGuid);
+            if (resolved == InvalidEntityId)
+                return InvalidEntityId;
 
-            return false;
+            trace.traceBasisCached = resolved;
+            return resolved;
+        }
+
+        bool TryGetBasisPose(World& world, EntityId basis, DirectX::XMFLOAT3& outPos, DirectX::XMFLOAT4& outRot)
+        {
+            const DirectX::XMMATRIX worldMatrix = world.ComputeWorldMatrix(basis);
+            DirectX::XMVECTOR s, r, t;
+            if (!DirectX::XMMatrixDecompose(&s, &r, &t, worldMatrix))
+                return false;
+
+            DirectX::XMStoreFloat3(&outPos, t);
+            DirectX::XMStoreFloat4(&outRot, r);
+            return true;
+        }
+
+        DirectX::XMMATRIX BuildBasisWorldMatrix(const DirectX::XMFLOAT3& pos, const DirectX::XMFLOAT4& rot)
+        {
+            using namespace DirectX;
+            const XMVECTOR q = XMLoadFloat4(&rot);
+            const XMMATRIX R = XMMatrixRotationQuaternion(q);
+            const XMMATRIX T = XMMatrixTranslation(pos.x, pos.y, pos.z);
+            return R * T;
+        }
+
+        DirectX::XMMATRIX BuildShapeLocalMatrix(const WeaponTraceShape& shape)
+        {
+            using namespace DirectX;
+            const float rx = XMConvertToRadians(shape.localRotDeg.x);
+            const float ry = XMConvertToRadians(shape.localRotDeg.y);
+            const float rz = XMConvertToRadians(shape.localRotDeg.z);
+            const XMMATRIX R = XMMatrixRotationRollPitchYaw(rx, ry, rz);
+            const XMMATRIX T = XMMatrixTranslation(shape.localPos.x, shape.localPos.y, shape.localPos.z);
+            return R * T;
+        }
+
+        bool ComputeShapeWorldPose(const WeaponTraceShape& shape, const DirectX::XMMATRIX& basisWorld,
+            DirectX::XMFLOAT3& outCenter, DirectX::XMFLOAT4& outRot)
+        {
+            using namespace DirectX;
+            const XMMATRIX local = BuildShapeLocalMatrix(shape);
+            const XMMATRIX world = local * basisWorld;
+            XMVECTOR s, r, t;
+            if (!XMMatrixDecompose(&s, &r, &t, world))
+                return false;
+
+            XMStoreFloat3(&outCenter, t);
+            XMStoreFloat4(&outRot, r);
+            return true;
         }
     }
 
@@ -121,14 +133,17 @@ namespace Alice
         {
             if (!trace.active)
             {
-                trace.prevPositions.clear();
-                trace.hasPrevPositions = false;
+                trace.hasPrevBasis = false;
+                trace.hasPrevShapes = false;
+                trace.prevCentersWS.clear();
+                trace.prevRotsWS.clear();
                 trace.hitVictims.clear();
                 continue;
             }
 
             const EntityId owner = ResolveOwner(world, trace, eid);
-            if (owner == InvalidEntityId || trace.traceSocketNames.empty())
+            const EntityId basis = ResolveTraceBasis(world, trace, eid);
+            if (owner == InvalidEntityId || basis == InvalidEntityId)
                 continue;
 
             if (trace.lastAttackInstanceId != trace.attackInstanceId)
@@ -137,37 +152,43 @@ namespace Alice
                 trace.lastAttackInstanceId = trace.attackInstanceId;
             }
 
-            const size_t socketCount = trace.traceSocketNames.size();
-            if (trace.prevPositions.size() != socketCount)
+            const size_t shapeCount = trace.shapes.size();
+            if (trace.prevCentersWS.size() != shapeCount || trace.prevRotsWS.size() != shapeCount)
             {
-                trace.prevPositions.assign(socketCount, DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f));
-                trace.hasPrevPositions = false;
+                trace.prevCentersWS.assign(shapeCount, DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f));
+                trace.prevRotsWS.assign(shapeCount, DirectX::XMFLOAT4(0.0f, 0.0f, 0.0f, 1.0f));
+                trace.hasPrevShapes = false;
             }
 
-            std::vector<DirectX::XMFLOAT3> currPositions(socketCount);
-            for (size_t i = 0; i < socketCount; ++i)
+            DirectX::XMFLOAT3 currBasisPos{};
+            DirectX::XMFLOAT4 currBasisRot{};
+            if (!TryGetBasisPose(world, basis, currBasisPos, currBasisRot))
+                continue;
+
+            std::vector<DirectX::XMFLOAT3> currCenters(shapeCount);
+            std::vector<DirectX::XMFLOAT4> currRots(shapeCount);
+            const DirectX::XMMATRIX currBasisWorld = BuildBasisWorldMatrix(currBasisPos, currBasisRot);
+            for (size_t i = 0; i < shapeCount; ++i)
             {
-                XMMATRIX socketWorld = XMMatrixIdentity();
-                if (!TryGetSocketWorldMatrix(world, owner, trace.traceSocketNames[i], socketWorld))
+                if (!ComputeShapeWorldPose(trace.shapes[i], currBasisWorld, currCenters[i], currRots[i]))
                 {
-                    currPositions[i] = trace.prevPositions[i];
-                    continue;
+                    currCenters[i] = (trace.hasPrevShapes && i < trace.prevCentersWS.size())
+                        ? trace.prevCentersWS[i]
+                        : DirectX::XMFLOAT3(0.0f, 0.0f, 0.0f);
+                    currRots[i] = (trace.hasPrevShapes && i < trace.prevRotsWS.size())
+                        ? trace.prevRotsWS[i]
+                        : DirectX::XMFLOAT4(0.0f, 0.0f, 0.0f, 1.0f);
                 }
-
-                XMVECTOR S, R, T;
-                if (!XMMatrixDecompose(&S, &R, &T, socketWorld))
-                {
-                    currPositions[i] = trace.prevPositions[i];
-                    continue;
-                }
-
-                XMStoreFloat3(&currPositions[i], T);
             }
 
-            if (!trace.hasPrevPositions)
+            if (!trace.hasPrevBasis || !trace.hasPrevShapes)
             {
-                trace.prevPositions = currPositions;
-                trace.hasPrevPositions = true;
+                trace.prevBasisPos = currBasisPos;
+                trace.prevBasisRot = currBasisRot;
+                trace.prevCentersWS = currCenters;
+                trace.prevRotsWS = currRots;
+                trace.hasPrevBasis = true;
+                trace.hasPrevShapes = true;
                 continue;
             }
 
@@ -186,70 +207,148 @@ namespace Alice
             std::vector<SweepHit> hits;
             hits.reserve(32);
 
-            for (size_t i = 0; i < socketCount; ++i)
+            const uint32_t steps = std::max(1u, trace.subSteps);
+            const DirectX::XMVECTOR prevBasisPosV = XMLoadFloat3(&trace.prevBasisPos);
+            const DirectX::XMVECTOR currBasisPosV = XMLoadFloat3(&currBasisPos);
+            const DirectX::XMVECTOR prevBasisRotV = XMLoadFloat4(&trace.prevBasisRot);
+            const DirectX::XMVECTOR currBasisRotV = XMLoadFloat4(&currBasisRot);
+
+            for (uint32_t step = 0; step < steps; ++step)
             {
-                const DirectX::XMFLOAT3& prev = trace.prevPositions[i];
-                const DirectX::XMFLOAT3& cur = currPositions[i];
-                const DirectX::XMFLOAT3 delta{ cur.x - prev.x, cur.y - prev.y, cur.z - prev.z };
+                const float t0 = static_cast<float>(step) / static_cast<float>(steps);
+                const float t1 = static_cast<float>(step + 1) / static_cast<float>(steps);
 
-                const float dist = std::sqrt(delta.x * delta.x + delta.y * delta.y + delta.z * delta.z);
-                if (dist < 0.0001f)
-                    continue;
+                DirectX::XMFLOAT3 basisStartPos{};
+                DirectX::XMFLOAT3 basisEndPos{};
+                DirectX::XMFLOAT4 basisStartRot{};
+                DirectX::XMFLOAT4 basisEndRot{};
 
-                const Vec3 origin(prev.x, prev.y, prev.z);
-                const Vec3 dir(delta.x / dist, delta.y / dist, delta.z / dist);
+                DirectX::XMStoreFloat3(&basisStartPos, DirectX::XMVectorLerp(prevBasisPosV, currBasisPosV, t0));
+                DirectX::XMStoreFloat3(&basisEndPos, DirectX::XMVectorLerp(prevBasisPosV, currBasisPosV, t1));
+                DirectX::XMStoreFloat4(&basisStartRot, DirectX::XMQuaternionSlerp(prevBasisRotV, currBasisRotV, t0));
+                DirectX::XMStoreFloat4(&basisEndRot, DirectX::XMQuaternionSlerp(prevBasisRotV, currBasisRotV, t1));
 
-                hits.clear();
-                const uint32_t hitCount = physics->SweepSphereAllQ(origin, trace.radius, dir, dist, hits, filter);
-                if (hitCount == 0)
-                    continue;
+                const DirectX::XMMATRIX basisStartWorld = BuildBasisWorldMatrix(basisStartPos, basisStartRot);
+                const DirectX::XMMATRIX basisEndWorld = BuildBasisWorldMatrix(basisEndPos, basisEndRot);
 
-                for (uint32_t h = 0; h < hitCount && h < hits.size(); ++h)
+                for (size_t i = 0; i < shapeCount; ++i)
                 {
-                    const auto& hit = hits[h];
-                    if (!hit.userData)
+                    const WeaponTraceShape& shape = trace.shapes[i];
+                    if (!shape.enabled)
                         continue;
 
-                    EntityId hitEntity = world.ExtractEntityIdFromUserData(hit.userData);
-                    if (hitEntity == InvalidEntityId)
+                    DirectX::XMFLOAT3 startCenter{};
+                    DirectX::XMFLOAT4 startRot{};
+                    DirectX::XMFLOAT3 endCenter{};
+                    DirectX::XMFLOAT4 endRot{};
+
+                    if (!ComputeShapeWorldPose(shape, basisStartWorld, startCenter, startRot))
+                        continue;
+                    if (!ComputeShapeWorldPose(shape, basisEndWorld, endCenter, endRot))
                         continue;
 
-                    auto* hurt = world.GetComponent<HurtboxComponent>(hitEntity);
-                    if (!hurt)
+                    const DirectX::XMFLOAT3 delta{ endCenter.x - startCenter.x, endCenter.y - startCenter.y, endCenter.z - startCenter.z };
+                    const float dist = std::sqrt(delta.x * delta.x + delta.y * delta.y + delta.z * delta.z);
+                    if (dist < 0.0001f)
                         continue;
 
-                    if (hurt->teamId == trace.teamId)
-                        continue;
+                    const Vec3 origin(startCenter.x, startCenter.y, startCenter.z);
+                    const Vec3 dir(delta.x / dist, delta.y / dist, delta.z / dist);
 
-                    const std::uint64_t victimGuid = (hurt->ownerGuid != 0)
-                        ? hurt->ownerGuid
-                        : static_cast<std::uint64_t>(hitEntity);
-
-                    if (trace.hitVictims.find(victimGuid) != trace.hitVictims.end())
-                        continue;
-
-                    trace.hitVictims.insert(victimGuid);
-
-                    if (outHits)
+                    hits.clear();
+                    uint32_t hitCount = 0;
+                    if (shape.type == WeaponTraceShapeType::Sphere)
                     {
-                        CombatHitEvent ev{};
-                        ev.attackerOwner = owner;
-                        ev.victimOwner = (hurt->ownerGuid != 0)
-                            ? world.FindEntityByGuid(hurt->ownerGuid)
-                            : (hurt->ownerCached != InvalidEntityId ? hurt->ownerCached : hitEntity);
-                        ev.hurtboxEntity = hitEntity;
-                        ev.part = hurt->part;
-                        ev.attackInstanceId = trace.attackInstanceId;
-                        ev.damage = trace.baseDamage * hurt->damageScale;
-                        ev.debugLog = trace.debugDraw;
-                        ev.hitPosWS = DirectX::XMFLOAT3(hit.position.x, hit.position.y, hit.position.z);
-                        ev.hitNormalWS = DirectX::XMFLOAT3(hit.normal.x, hit.normal.y, hit.normal.z);
-                        outHits->push_back(ev);
+                        hitCount = physics->SweepSphereAllQ(origin, shape.radius, dir, dist, hits, filter);
+                    }
+                    else if (shape.type == WeaponTraceShapeType::Capsule)
+                    {
+                        const Quat rot(startRot.x, startRot.y, startRot.z, startRot.w);
+                        hitCount = physics->SweepCapsuleAllQ(origin, rot, shape.radius, shape.capsuleHalfHeight, dir, dist, hits, filter, 64, true);
+                    }
+                    else if (shape.type == WeaponTraceShapeType::Box)
+                    {
+                        const Quat rot(startRot.x, startRot.y, startRot.z, startRot.w);
+                        const Vec3 halfExtents(shape.boxHalfExtents.x, shape.boxHalfExtents.y, shape.boxHalfExtents.z);
+                        hitCount = physics->SweepBoxAllQ(origin, rot, halfExtents, dir, dist, hits, filter);
+                    }
+
+                    if (hitCount == 0)
+                        continue;
+
+                    for (uint32_t h = 0; h < hitCount && h < hits.size(); ++h)
+                    {
+                        const auto& hit = hits[h];
+                        if (!hit.userData)
+                            continue;
+
+                        EntityId hitEntity = world.ExtractEntityIdFromUserData(hit.userData);
+                        if (hitEntity == InvalidEntityId)
+                            continue;
+
+                        auto* hurt = world.GetComponent<HurtboxComponent>(hitEntity);
+                        if (!hurt)
+                            continue;
+
+                        if (hurt->teamId == trace.teamId)
+                            continue;
+
+                        const std::uint64_t victimGuid = (hurt->ownerGuid != 0)
+                            ? hurt->ownerGuid
+                            : static_cast<std::uint64_t>(hitEntity);
+
+                        if (trace.hitVictims.find(victimGuid) != trace.hitVictims.end())
+                            continue;
+
+                        trace.hitVictims.insert(victimGuid);
+
+                        if (outHits)
+                        {
+                            const EntityId victimOwner = (hurt->ownerGuid != 0)
+                                ? world.FindEntityByGuid(hurt->ownerGuid)
+                                : (hurt->ownerCached != InvalidEntityId ? hurt->ownerCached : hitEntity);
+
+                            if (trace.debugDraw)
+                            {
+                                const char* typeName = (shape.type == WeaponTraceShapeType::Sphere)
+                                    ? "Sphere"
+                                    : (shape.type == WeaponTraceShapeType::Capsule ? "Capsule" : "Box");
+                                ALICE_LOG_INFO("[WeaponTrace] Hit attacker=%llu victim=%llu hurtbox=%llu part=%u dmg=%.2f attackId=%u shape=%s type=%s layerMask=0x%08X queryMask=0x%08X pos=(%.2f,%.2f,%.2f)",
+                                    static_cast<unsigned long long>(owner),
+                                    static_cast<unsigned long long>(victimOwner),
+                                    static_cast<unsigned long long>(hitEntity),
+                                    hurt->part,
+                                    trace.baseDamage * hurt->damageScale,
+                                    trace.attackInstanceId,
+                                    shape.name.c_str(),
+                                    typeName,
+                                    targetLayerBits,
+                                    queryLayerBits,
+                                    hit.position.x, hit.position.y, hit.position.z);
+                            }
+
+                            CombatHitEvent ev{};
+                            ev.attackerOwner = owner;
+                            ev.victimOwner = victimOwner;
+                            ev.hurtboxEntity = hitEntity;
+                            ev.part = hurt->part;
+                            ev.attackInstanceId = trace.attackInstanceId;
+                            ev.damage = trace.baseDamage * hurt->damageScale;
+                            ev.debugLog = trace.debugDraw;
+                            ev.hitPosWS = DirectX::XMFLOAT3(hit.position.x, hit.position.y, hit.position.z);
+                            ev.hitNormalWS = DirectX::XMFLOAT3(hit.normal.x, hit.normal.y, hit.normal.z);
+                            outHits->push_back(ev);
+                        }
                     }
                 }
             }
 
-            trace.prevPositions = currPositions;
+            trace.prevBasisPos = currBasisPos;
+            trace.prevBasisRot = currBasisRot;
+            trace.prevCentersWS = currCenters;
+            trace.prevRotsWS = currRots;
+            trace.hasPrevBasis = true;
+            trace.hasPrevShapes = true;
         }
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #https://github.com/Cosmic-Disaster/AliceEngine/issues/80

## 📝 작업 내용

```c++
								transform->position = newPosition;
								transform->rotation = newRotation;  // (x=pitch, y=yaw, z=roll) 라디안
								transform->scale = newScale;
```

아래 내용으로 변경해서 문제를 해결함

```c++
								if (gizmoOp == ImGuizmo::TRANSLATE)
								{
									transform->position = newPosition;
								}
								else if (gizmoOp == ImGuizmo::ROTATE)
								{
									transform->rotation = newRotation;  // (x=pitch, y=yaw, z=roll) 라디안
								}
								else if (gizmoOp == ImGuizmo::SCALE)
								{
									transform->scale = newScale;
								}
							
```

장기적인 관점으로 봤을 때,
오일러각 - 쿼터니언을 어느정도 통합할 필요가 있음
 
엔진 내부 회전은 Quaternion으로 저장/연산하고
Inspector에서만 Euler로 보여주고, 입력받으면 Quaternion으로 반영하는 방식으로 리펙토링이 필요함